### PR TITLE
Move isLeapYear to DateUtils

### DIFF
--- a/src/main/java/com/github/rkumsher/date/DateUtils.java
+++ b/src/main/java/com/github/rkumsher/date/DateUtils.java
@@ -1,14 +1,40 @@
 package com.github.rkumsher.date;
 
+import static com.google.common.base.Preconditions.*;
+import static java.time.Month.FEBRUARY;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.MonthDay;
 import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 
 /** Utility library for working with {@link Date}s. */
 public final class DateUtils {
 
+  /** February 29th. */
+  static final MonthDay LEAP_DAY = MonthDay.of(FEBRUARY, 29);
+
   private DateUtils() {}
+
+  /**
+   * Returns whether or not the given {@link TemporalAccessor} is leap day (February 29th).
+   *
+   * @return whether or not the given {@link TemporalAccessor} is leap day
+   * @throws IllegalArgumentException if the given {@link TemporalAccessor} does not support {@link
+   *     ChronoField#MONTH_OF_YEAR} or {@link ChronoField#DAY_OF_MONTH}
+   */
+  public static boolean isLeapDay(TemporalAccessor temporal) {
+    checkArgument(
+        temporal.isSupported(MONTH_OF_YEAR), "%s does not support MONTH_OF_YEAR", temporal);
+    checkArgument(temporal.isSupported(DAY_OF_MONTH), "%s does not support DAY_OF_MONTH", temporal);
+    MonthDay monthDay = MonthDay.from(temporal);
+    return monthDay.equals(LEAP_DAY);
+  }
 
   /**
    * Returns the {@link Date} of midnight at the start of the given {@link Date}.

--- a/src/main/java/com/github/rkumsher/date/RandomDateUtils.java
+++ b/src/main/java/com/github/rkumsher/date/RandomDateUtils.java
@@ -1,5 +1,6 @@
 package com.github.rkumsher.date;
 
+import static com.github.rkumsher.date.DateUtils.LEAP_DAY;
 import static com.github.rkumsher.number.RandomNumberUtils.randomInt;
 import static com.github.rkumsher.number.RandomNumberUtils.randomLong;
 import static com.github.rkumsher.number.RandomNumberUtils.randomNegativeInt;
@@ -8,7 +9,6 @@ import static com.github.rkumsher.number.RandomNumberUtils.randomPositiveInt;
 import static com.github.rkumsher.number.RandomNumberUtils.randomPositiveLong;
 import static com.google.common.base.Preconditions.*;
 import static java.time.Month.DECEMBER;
-import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
 import static java.time.temporal.ChronoField.NANO_OF_DAY;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -54,7 +54,6 @@ public final class RandomDateUtils {
   private static final int MAX_ZONE_OFFSET_SECONDS = 64800;
   private static final int MIN_YEAR = 1970;
   private static final int MAX_YEAR = 9999;
-  static final MonthDay LEAP_DAY = MonthDay.of(FEBRUARY, 29);
   /** 1970-01-01T00:00:00Z. */
   static final Instant MIN_INSTANT = Instant.ofEpochMilli(0);
   /** December 31st, 9999. */
@@ -672,19 +671,10 @@ public final class RandomDateUtils {
     Month month = randomMonth();
     int dayOfMonth = RandomUtils.nextInt(1, month.maxLength() + 1);
     MonthDay monthDay = MonthDay.of(month, dayOfMonth);
-    if (!includeLeapDay && isLeapDay(monthDay)) {
+    if (!includeLeapDay && DateUtils.isLeapDay(monthDay)) {
       return randomMonthDay(false);
     }
     return monthDay;
-  }
-
-  /**
-   * Returns whether or not the given {@link MonthDay} is leap day (February 29th).
-   *
-   * @return whether or not the given {@link MonthDay} is leap day
-   */
-  static boolean isLeapDay(MonthDay monthDay) {
-    return LEAP_DAY.equals(monthDay);
   }
 
   /**

--- a/src/test/java/com/github/rkumsher/date/DateUtilsTest.java
+++ b/src/test/java/com/github/rkumsher/date/DateUtilsTest.java
@@ -1,10 +1,17 @@
 package com.github.rkumsher.date;
 
+import static com.github.rkumsher.date.DateUtils.isLeapDay;
+import static com.github.rkumsher.date.RandomDateUtils.randomMonthDay;
+import static java.time.Month.FEBRUARY;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.Year;
 import java.util.Date;
 
 import org.junit.Test;
@@ -14,6 +21,53 @@ public class DateUtilsTest {
   private static final Date TODAY = new Date();
   private static final LocalDateTime START_OF_TODAY = LocalDateTime.now().with(LocalTime.MIN);
   private static final LocalDateTime END_OF_TODAY = LocalDateTime.now().with(LocalTime.MAX);
+
+  @Test
+  public void isLeapDay_WhenAccessorDoesNotSupportMonthOfYear_ThrowsIllegalArgumentException() {
+    Year year = Year.now();
+    try {
+      isLeapDay(year);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(year + " does not support MONTH_OF_YEAR"));
+    }
+  }
+
+  @Test
+  public void isLeapDay_WhenAccessorDoesNotSupportDayOfMonth_ThrowsIllegalArgumentException() {
+    Month month = Month.FEBRUARY;
+    try {
+      isLeapDay(month);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(month + " does not support DAY_OF_MONTH"));
+    }
+  }
+
+  @Test
+  public void isLeapDay_WithFebruaryTwentyNinth_MonthDay_ReturnsTrue() {
+    MonthDay monthDay = MonthDay.of(FEBRUARY, 29);
+    assertThat(isLeapDay(monthDay), is(true));
+  }
+
+  @Test
+  public void isLeapDay_WithFebruaryTwentyEighth_MonthDay_ReturnsFalse() {
+    MonthDay monthDay = randomMonthDay(false);
+    assertThat(isLeapDay(monthDay), is(false));
+  }
+
+  @Test
+  public void isLeapDay_WithFebruaryTwentyNinth_LocalDate_ReturnsTrue() {
+    LocalDate localDate =
+        LocalDate.now().withYear(2000).withMonth(FEBRUARY.getValue()).withDayOfMonth(29);
+    assertThat(isLeapDay(localDate), is(true));
+  }
+
+  @Test
+  public void isLeapDay_WithFebruaryTwentyEighth_LocalDate_ReturnsFalse() {
+    LocalDate localDate = LocalDate.now().withMonth(FEBRUARY.getValue()).withDayOfMonth(28);
+    assertThat(isLeapDay(localDate), is(false));
+  }
 
   @Test
   public void atStartOfDay_WithToday_ReturnsStartOfToday() {

--- a/src/test/java/com/github/rkumsher/date/RandomDateUtilsTest.java
+++ b/src/test/java/com/github/rkumsher/date/RandomDateUtilsTest.java
@@ -1,9 +1,8 @@
 package com.github.rkumsher.date;
 
-import static com.github.rkumsher.date.RandomDateUtils.LEAP_DAY;
+import static com.github.rkumsher.date.DateUtils.LEAP_DAY;
 import static com.github.rkumsher.date.RandomDateUtils.MAX_INSTANT;
 import static com.github.rkumsher.date.RandomDateUtils.MIN_INSTANT;
-import static com.github.rkumsher.date.RandomDateUtils.isLeapDay;
 import static com.github.rkumsher.date.RandomDateUtils.random;
 import static com.github.rkumsher.date.RandomDateUtils.randomAfter;
 import static com.github.rkumsher.date.RandomDateUtils.randomBefore;
@@ -66,7 +65,6 @@ import static com.github.rkumsher.date.RandomDateUtils.randomZonedDateTime;
 import static com.github.rkumsher.date.RandomDateUtils.randomZonedDateTimeAfter;
 import static com.github.rkumsher.date.RandomDateUtils.randomZonedDateTimeBefore;
 import static java.time.Month.DECEMBER;
-import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -75,6 +73,8 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.YEARS;
+import static org.apache.commons.lang3.time.DateUtils.addDays;
+import static org.apache.commons.lang3.time.DateUtils.addMilliseconds;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.isOneOf;
@@ -100,7 +100,6 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalField;
 import java.util.Date;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Test;
 
 import com.github.rkumsher.enums.RandomEnumUtils;
@@ -648,8 +647,8 @@ public class RandomDateUtilsTest {
 
   @Test
   public void randomDate_ReturnsDateBetweenGivenDates() {
-    Date start = DateUtils.addDays(new Date(), -1);
-    Date end = DateUtils.addDays(new Date(), 1);
+    Date start = addDays(new Date(), -1);
+    Date end = addDays(new Date(), 1);
 
     Date zonedDateTime = randomDate(start, end);
     assertTrue(zonedDateTime.after(start) || zonedDateTime.equals(start));
@@ -659,7 +658,7 @@ public class RandomDateUtilsTest {
   @Test
   public void randomDate_WithDatesOneMillisecondApart_ReturnsStart() {
     Date start = new Date();
-    Date end = DateUtils.addMilliseconds(start, 1);
+    Date end = addMilliseconds(start, 1);
     assertThat(randomDate(start, end), is(start));
   }
 
@@ -691,8 +690,8 @@ public class RandomDateUtilsTest {
 
   @Test
   public void randomDate_WithStartAfterEndDate_ThrowsIllegalArgumentException() {
-    Date start = DateUtils.addDays(new Date(), 1);
-    Date end = DateUtils.addDays(new Date(), -1);
+    Date start = addDays(new Date(), 1);
+    Date end = addDays(new Date(), -1);
     try {
       randomDate(start, end);
       fail("Should have thrown an IllegalArgumentException");
@@ -1147,23 +1146,11 @@ public class RandomDateUtilsTest {
   }
 
   @Test
-  public void isLeapDay_WithFebruaryTwentyNinth_ReturnsTrue() {
-    MonthDay monthDay = MonthDay.of(FEBRUARY, 29);
-    assertThat(isLeapDay(monthDay), is(true));
-  }
-
-  @Test
-  public void isLeapDay_WithNotFebruaryTwentyNinth_ReturnsFalse() {
-    MonthDay monthDay = randomMonthDay(false);
-    assertThat(isLeapDay(monthDay), is(false));
-  }
-
-  @Test
   public void randomMonthDay_DoesNotReturnLeapDayIfCurrentYearIsNotLeapYear() {
     MonthDay monthDay = randomMonthDay();
     assertThat(monthDay, notNullValue());
     if (!Year.now().isLeap()) {
-      assertThat(monthDay, not(isLeapDay(monthDay)));
+      assertThat(monthDay, not(DateUtils.isLeapDay(monthDay)));
     }
   }
 


### PR DESCRIPTION
Currently, isLeapYear is in RandomDateUtils and is package-private. Move to DateUtils and make public.
Also relax the type to accept TemporalAccessor instead of just MonthDay

Fixes #20